### PR TITLE
Fixed KGXSupport and KGXH2Ow tank types not found

### DIFF
--- a/GameData/SpaceY/SpaceYLifters/Compatibility/B9FuelSwitch.cfg
+++ b/GameData/SpaceY/SpaceYLifters/Compatibility/B9FuelSwitch.cfg
@@ -64,14 +64,14 @@
 		{
 			name = Support
 			title = #KGX-B9-support // Support // EC+MP
-			tankType = KGXSupport
+			tankType = KGExSupport
 			defaultSubtypePriority = 50
 		}
 		SUBTYPE:NEEDS[CommunityResourcePack,KGEx]
 		{
 			name = H2Ow
 			title = #LOC_CRP_Hydrogen_DisplayName // Hydrogen (fix below)
-			tankType = KGXH2Ow
+			tankType = KGExH2Ow
 			defaultSubtypePriority = 40
 	
 			tmp0 = #LOC_CRP_Oxygen_DisplayName // Oxygen


### PR DESCRIPTION
Assuming the correct KGEx mod is https://github.com/zer0Kerbal/KGEx
(Otherwise please point me to the correct one)